### PR TITLE
Feature metadata

### DIFF
--- a/src/alfred/__init__.py
+++ b/src/alfred/__init__.py
@@ -43,15 +43,13 @@ class Experiment(object):
     |
     '''
 
-    def __init__(self, exp_type=None, exp_name=None, exp_version=None, exp_author_mail=None, config_string='', basepath=None, custom_layout=None):
+    def __init__(self, type=None, title=None, version=None, author=None, config_string='', basepath=None, custom_layout=None):
         '''
-        :param str exp_type: Typ des Experiments.
-        :param str exp_name: Name des Experiments.
-        :param str exp_version: Version des Experiments.
-        :param str exp_author_mail: E-Mail Adresse des/der Autor*in des Experiments. Für den Zugriff auf die Daten aus Mortimer sollte hier die gleiche Mail-Adresse verwendet werden, wie bei der Registrierung in Mortimer.
-        :param layout custom_layout: Optionaler Parameter, um das Experiment mit eigenem Custom layout zu starten
-
-        .. note:: mindestens exp_type und exp_name müssen beim Aufruf übergeben werden!
+        :param str type: Experiment type.
+        :param str title: Experiment title.
+        :param str version: Experiment version.
+        :param str author: Experiment author. If a local experiment saves data to mortimer, this should be the mortimer username.
+        :param layout custom_layout: Optional parameter for starting the experiment with a custom layout.
 
         |
 
@@ -82,15 +80,16 @@ class Experiment(object):
 
         # get experiment metadata
         # the if-else clauses ensure backwards compatibility, if users defined the metadata in script.py
-        self._author_mail = exp_author_mail if exp_author_mail else settings.experiment.author_mail
-        self._name = exp_name if exp_name else settings.experiment.title
-        self._version = exp_version if exp_version else settings.experiment.version
-        self._type = exp_type if exp_type else settings.experiment.type
+        self._author = author if author else settings.experiment.author
+        self._title = title if title else settings.experiment.title
+        self._version = version if version else settings.experiment.version
+        self._type = type if type else settings.experiment.type
 
+        # FOR BACKWARDS COMPATIBILITY
         # raise errors if user defined metadata in script.py that doesn't match the data given in config.conf
-        if self._name != settings.experiment.title:
+        if self._title != settings.experiment.title:
             raise RuntimeError("Experiment titles must be equal in script and config file.")
-        if self._author_mail != settings.experiment.author_mail:
+        if self._author != settings.experiment.author:
             raise RuntimeError("Experiment authors must be equal in script and config file.")
         if self._version != settings.experiment.version:
             raise RuntimeError("Experiment versions must be equal in script and config file")
@@ -99,7 +98,7 @@ class Experiment(object):
 
         #: Uid des Experiments
         self._uuid = uuid4().hex
-        logger.info("Alfred %s experiment session initialized! Alfred version: %s, experiment name: %s, experiment version: %s" % (self._type, __version__, self._name, self._version), self)
+        logger.info("Alfred %s experiment session initialized! Alfred version: %s, experiment name: %s, experiment version: %s" % (self._type, __version__, self._title, self._version), self)
 
         self._settings = settings.ExperimentSpecificSettings(config_string)
         self._message_manager = messages.MessageManager()
@@ -139,10 +138,11 @@ class Experiment(object):
         if basepath is not None:
             logger.warning("Usage of basepath is depricated.", self)
 
-    def update(self, name, version, author):
-        self._name = name
+    def update(self, title, version, author, type="web"):
+        self._title = title
         self._version = version
-        self._author_mail = author
+        self._author = author
+        self._type = type
 
     def start(self):
         '''
@@ -172,20 +172,20 @@ class Experiment(object):
         self._saving_agent_controller.run_saving_agents(99)
 
     @property
-    def author_mail(self):
+    def author(self):
         '''
         Achtung: *read-only*
 
-        :return: E-Mail des/der Autor*in **author_mail** (*str*)
+        :return: Experiment author **author** (*str*)
         '''
-        return self._author_mail
+        return self._author
 
     @property
     def type(self):
         '''
         Achtung: *read-only*
 
-        :return: Experimenttyp **exp_type** (*str*)
+        :return: Type of experiment **type** (*str*)
         '''
 
         return self._type
@@ -195,18 +195,18 @@ class Experiment(object):
         '''
         Achtung: *read-only*
 
-        :return: Experimentversion **exp_version** (*str*)
+        :return: Experiment version **version** (*str*)
         '''
         return self._version
 
     @property
-    def name(self):
+    def title(self):
         '''
         Achtung: *read-only*
 
-        :return: Experimentname **exp_name** (*str*)
+        :return: Experiment title **title** (*str*)
         '''
-        return self._name
+        return self._title
 
     @property
     def start_timestamp(self):

--- a/src/alfred/__init__.py
+++ b/src/alfred/__init__.py
@@ -125,11 +125,12 @@ class Experiment(object):
         if basepath is not None:
             logger.warning("Usage of basepath is depricated.", self)
 
-    def update(self, title, version, author, type="web"):
+    def update(self, title, version, author, uuid, type="web"):
         self._title = title
         self._version = version
         self._author = author
         self._type = type
+        self._uuid = uuid
 
     def start(self):
         '''

--- a/src/alfred/__init__.py
+++ b/src/alfred/__init__.py
@@ -43,7 +43,7 @@ class Experiment(object):
     |
     '''
 
-    def __init__(self, config_string='', basepath=None, custom_layout=None):
+    def __init__(self, exp_type=None, exp_name=None, exp_version=None, config_string='', basepath=None, custom_layout=None):
         '''
         :param layout custom_layout: Optional parameter for starting the experiment with a custom layout.
 
@@ -73,6 +73,9 @@ class Experiment(object):
         |
         |
         '''
+
+        if exp_type or exp_name or exp_version:
+            raise SyntaxError("The definition of experiment title, type, or version in script.py is deprecated. Please define these parameters in config.conf. In your script.py, just use 'exp = Experiment()'.")
 
         # get experiment metadata
         self._author = settings.experiment.author

--- a/src/alfred/__init__.py
+++ b/src/alfred/__init__.py
@@ -43,12 +43,8 @@ class Experiment(object):
     |
     '''
 
-    def __init__(self, type=None, title=None, version=None, author=None, config_string='', basepath=None, custom_layout=None):
+    def __init__(self, config_string='', basepath=None, custom_layout=None):
         '''
-        :param str type: Experiment type.
-        :param str title: Experiment title.
-        :param str version: Experiment version.
-        :param str author: Experiment author. If a local experiment saves data to mortimer, this should be the mortimer username.
         :param layout custom_layout: Optional parameter for starting the experiment with a custom layout.
 
         |
@@ -79,22 +75,10 @@ class Experiment(object):
         '''
 
         # get experiment metadata
-        # the if-else clauses ensure backwards compatibility, if users defined the metadata in script.py
-        self._author = author if author else settings.experiment.author
-        self._title = title if title else settings.experiment.title
-        self._version = version if version else settings.experiment.version
-        self._type = type if type else settings.experiment.type
-
-        # FOR BACKWARDS COMPATIBILITY
-        # raise errors if user defined metadata in script.py that doesn't match the data given in config.conf
-        if self._title != settings.experiment.title:
-            raise RuntimeError("Experiment titles must be equal in script and config file.")
-        if self._author != settings.experiment.author:
-            raise RuntimeError("Experiment authors must be equal in script and config file.")
-        if self._version != settings.experiment.version:
-            raise RuntimeError("Experiment versions must be equal in script and config file")
-        if self._type != settings.experiment.type:
-            raise RuntimeError("Experiment types must be equal in script and config file.")
+        self._author = settings.experiment.author
+        self._title = settings.experiment.title
+        self._version = settings.experiment.version
+        self._type = settings.experiment.type
 
         #: Uid des Experiments
         self._uuid = uuid4().hex

--- a/src/alfred/__init__.py
+++ b/src/alfred/__init__.py
@@ -43,7 +43,7 @@ class Experiment(object):
     |
     '''
 
-    def __init__(self, exp_type, exp_name, exp_version, exp_author_mail, config_string='', basepath=None, custom_layout=None):
+    def __init__(self, exp_type=None, exp_name=None, exp_version=None, exp_author_mail=None, config_string='', basepath=None, custom_layout=None):
         '''
         :param str exp_type: Typ des Experiments.
         :param str exp_name: Name des Experiments.
@@ -80,22 +80,22 @@ class Experiment(object):
         |
         '''
 
-        if type(exp_name) != str or exp_name == '' or type(exp_version) != str or exp_version == '' or not(exp_type == 'qt' or
-                                                                                                           exp_type == 'web' or exp_type == 'qt-wk'):
-            raise ValueError("exp_name and exp_version must be a non empty strings and exp_type must be 'qt' or 'web'")
+        # get experiment metadata
+        # the if-else clauses ensure backwards compatibility, if users defined the metadata in script.py
+        self._author_mail = exp_author_mail if exp_author_mail else settings.experiment.author_mail
+        self._name = exp_name if exp_name else settings.experiment.title
+        self._version = exp_version if exp_version else settings.experiment.version
+        self._type = exp_type if exp_type else settings.experiment.type
 
-        self._author_mail = exp_author_mail
-
-        #: Name des Experiments
-        self._name = exp_name
-
-        #: Version des Experiments
-        self._version = exp_version
-
-        #: Typ des Experiments
-        self._type = exp_type
+        # raise errors if user defined metadata in script.py that doesn't match the data given in config.conf
+        if self._name != settings.experiment.title:
+            raise RuntimeError("Experiment titles must be equal in script and config file.")
+        if self._author_mail != settings.experiment.author_mail:
+            raise RuntimeError("Experiment authors must be equal in script and config file.")
+        if self._version != settings.experiment.version:
+            raise RuntimeError("Experiment versions must be equal in script and config file")
         if self._type != settings.experiment.type:
-            raise RuntimeError("experiment types must be equal in script and config file")
+            raise RuntimeError("Experiment types must be equal in script and config file.")
 
         #: Uid des Experiments
         self._uuid = uuid4().hex

--- a/src/alfred/__init__.py
+++ b/src/alfred/__init__.py
@@ -83,8 +83,11 @@ class Experiment(object):
         self._version = settings.experiment.version
         self._type = settings.experiment.type
 
-        #: Uid des Experiments
+        # Uids for experiment and session
         self._uuid = uuid4().hex
+        self._sessionid = uuid4().hex
+
+        # Experiment startup message
         logger.info("Alfred %s experiment session initialized! Alfred version: %s, experiment name: %s, experiment version: %s" % (self._type, __version__, self._title, self._version), self)
 
         self._settings = settings.ExperimentSpecificSettings(config_string)
@@ -211,6 +214,10 @@ class Experiment(object):
     @property
     def uuid(self):
         return self._uuid
+
+    @property
+    def sessionid(self):
+        return self._sessionid
 
     @property
     def user_interface_controller(self):

--- a/src/alfred/__init__.py
+++ b/src/alfred/__init__.py
@@ -139,6 +139,11 @@ class Experiment(object):
         if basepath is not None:
             logger.warning("Usage of basepath is depricated.", self)
 
+    def update(self, name, version, author):
+        self._name = name
+        self._version = version
+        self._author_mail = author
+
     def start(self):
         '''
         Startet das Experiment, wenn die Bereitstellung lokal erfolgt.

--- a/src/alfred/alfredlog.py
+++ b/src/alfred/alfredlog.py
@@ -77,7 +77,7 @@ class NewLogger(object):
     def debug(self, msg, experiment=None, *args, **kwargs):
         if experiment:
             try:
-                msg = 'id=%s' % experiment.uuid[:6] + ' - ' + msg
+                msg = 'experiment id={exp}, session id={session}'.format(exp=experiment.uuid[:6], session=experiment.sessionid) + ' - ' + msg
             except Exception:
                 pass
         return self.logger.debug(msg, *args, **kwargs)
@@ -85,7 +85,7 @@ class NewLogger(object):
     def info(self, msg, experiment=None, *args, **kwargs):
         if experiment:
             try:
-                msg = 'id=%s' % experiment.uuid[:6] + ' - ' + msg
+                msg = 'experiment id={exp}, session id={session}'.format(exp=experiment.uuid[:6], session=experiment.sessionid) + ' - ' + msg
             except Exception:
                 pass
         return self.logger.info(msg, *args, **kwargs)
@@ -93,7 +93,7 @@ class NewLogger(object):
     def warning(self, msg, experiment=None, *args, **kwargs):
         if experiment:
             try:
-                msg = 'id=%s' % experiment.uuid[:6] + ' - ' + msg
+                msg = 'experiment id={exp}, session id={session}'.format(exp=experiment.uuid[:6], session=experiment.sessionid) + ' - ' + msg
             except Exception:
                 pass
         return self.logger.warning(msg, *args, **kwargs)
@@ -101,7 +101,7 @@ class NewLogger(object):
     def error(self, msg, experiment=None, *args, **kwargs):
         if experiment:
             try:
-                msg = 'id=%s' % experiment.uuid[:6] + ' - ' + msg
+                msg = 'experiment id={exp}, session id={session}'.format(exp=experiment.uuid[:6], session=experiment.sessionid) + ' - ' + msg
             except Exception:
                 pass
         return self.logger.error(msg, *args, **kwargs)
@@ -109,7 +109,7 @@ class NewLogger(object):
     def critical(self, msg, experiment=None, *args, **kwargs):
         if experiment:
             try:
-                msg = 'id=%s' % experiment.uuid[:6] + ' - ' + msg
+                msg = 'experiment id={exp}, session id={session}'.format(exp=experiment.uuid[:6], session=experiment.sessionid) + ' - ' + msg
             except Exception:
                 pass
         return self.logger.critical(msg, *args, **kwargs)
@@ -117,7 +117,7 @@ class NewLogger(object):
     def log(self, lvl, msg, experiment=None, *args, **kwargs):
         if experiment:
             try:
-                msg = 'id=%s' % experiment.uuid[:6] + ' - ' + msg
+                msg = 'experiment id={exp}, session id={session}'.format(exp=experiment.uuid[:6], session=experiment.sessionid) + ' - ' + msg
             except Exception:
                 pass
         return self.logger.log(lvl, msg, *args, **kwargs)
@@ -125,7 +125,7 @@ class NewLogger(object):
     def exception(self, msg, experiment=None, *args):
         if experiment:
             try:
-                msg = 'id=%s' % experiment.uuid[:6] + ' - ' + msg
+                msg = 'experiment id={exp}, session id={session}'.format(exp=experiment.uuid[:6], session=experiment.sessionid) + ' - ' + msg
             except Exception:
                 pass
         return self.logger.exception(msg, *args)

--- a/src/alfred/data_manager.py
+++ b/src/alfred/data_manager.py
@@ -22,8 +22,8 @@ class DataManager(object):
 
     def get_data(self):
         data = self._experiment.page_controller.data
-        data['exp_author_mail'] = self._experiment.author_mail
-        data['exp_name'] = self._experiment.name
+        data['exp_author'] = self._experiment.author
+        data['exp_title'] = self._experiment.title
         data['exp_version'] = self._experiment.version
         data['exp_type'] = self._experiment.type
         data['start_time'] = self._experiment._start_time

--- a/src/alfred/data_manager.py
+++ b/src/alfred/data_manager.py
@@ -32,6 +32,7 @@ class DataManager(object):
         data['exp_session'] = self._experiment.session
         data['exp_condition'] = self._experiment.condition
         data['exp_uuid'] = self._experiment.uuid
+        data['session_id'] = self._experiment.sessionid
         data['additional_data'] = self._additional_data
 
         return data

--- a/src/alfred/files/default.conf
+++ b/src/alfred/files/default.conf
@@ -5,7 +5,7 @@ external_files_dir = .
 
 [experiment]
 title = 
-author_mail = 
+author = 
 version = 
 type = web
 qt_fullscreen = false

--- a/src/alfred/files/default.conf
+++ b/src/alfred/files/default.conf
@@ -4,9 +4,12 @@ debug = false
 external_files_dir = .
 
 [experiment]
-web_layout = BaseWebLayout
+title = 
+author_mail = 
+version = 
 type = web
-qt_fullscreen = true
+qt_fullscreen = false
+web_layout = BaseWebLayout
 
 ; this section once belonged to global.conf
 [webserver]

--- a/src/alfred/page.py
+++ b/src/alfred/page.py
@@ -398,7 +398,8 @@ class ExperimentFinishPage(CompositePage):
             exp_infos = '<table style="border-style: none"><tr><td width="200">Experimentname:</td><td>' + self._experiment.name + '</td></tr>'
             exp_infos = exp_infos + '<tr><td>Experimenttyp:</td><td>' + self._experiment.type + '</td></tr>'
             exp_infos = exp_infos + '<tr><td>Experimentversion:</td><td>' + self._experiment.version + '</td></tr>'
-            exp_infos = exp_infos + '<tr><td>Session-ID:</td><td>' + self._experiment.uuid + '</td></tr>'
+            exp_infos = exp_infos + '<tr><td>Experiment-ID:</td><td>' + self._experiment.uuid + '</td></tr>'
+            exp_infos = exp_infos + '<tr><td>Session-ID:</td><td>' + self._experiment.sessionid + '</td></tr>'
             exp_infos = exp_infos + '<tr><td>Log-ID:</td><td>' + self._experiment.uuid[:6] + '</td></tr>'
             exp_infos = exp_infos + '</table>'
 

--- a/src/alfred/saving_agent.py
+++ b/src/alfred/saving_agent.py
@@ -350,7 +350,7 @@ class LocalSavingAgent(SavingAgent):
         if not os.access(filepath, os.W_OK):
             raise RuntimeError("save path '%s' must be writable" % filepath)
 
-        filename = '%s_%s_%s.json' % (time.strftime('%Y-%m-%d_t%H%M%S'), filename, self._experiment.uuid)
+        filename = '%s_%s_%s.json' % (time.strftime('%Y-%m-%d_t%H%M%S'), filename, self._experiment.sessionid)
         self._file = os.path.join(filepath, filename)
 
         if os.path.exists(self._file):
@@ -380,7 +380,7 @@ class CouchDBSavingAgent(SavingAgent):
         except Exception as e:
             raise SavingAgentException('Type: %s' % type(e))
 
-        self._doc_id = self._experiment.uuid
+        self._doc_id = self._experiment.sessionid
         self._doc_rev = None
 
     def _save(self, data):
@@ -416,7 +416,7 @@ class MongoSavingAgent(SavingAgent):
 
         self._col = self._db[collection]
 
-        self._doc_id = self._experiment.uuid
+        self._doc_id = self._experiment.sessionid
 
     def _save(self, data):
 

--- a/src/alfred/settings.py
+++ b/src/alfred/settings.py
@@ -116,10 +116,22 @@ if not os.path.isabs(general.external_files_dir):
 
 # experiment
 experiment = _DictObj()
+experiment.title = _config_parser.get('experiment', 'title')
+experiment.author_mail = _config_parser.get('experiment', 'author_mail')
+experiment.version = _config_parser.get('experiment', 'version')
 experiment.type = _config_parser.get('experiment', 'type')
+experiment.qt_full_screen = _config_parser.getboolean('experiment', 'qt_fullscreen')
+
+# check if metadata is given correctly
+if not experiment.title:
+    raise ValueError("You need to define an experiment title in config.conf")
+if not experiment.author_mail:
+    raise ValueError("You need to define 'author_mail' in config.conf")
+if not experiment.version:
+    raise ValueError("You need to define an experiment version in config.conf")
 if not (experiment.type == 'qt' or experiment.type == 'web' or experiment.type == 'qt-wk'):
     raise ValueError("experiment.type must be qt, qt-wk or web")
-experiment.qt_full_screen = _config_parser.getboolean('experiment', 'qt_fullscreen')
+
 
 # logging
 log = _DictObj()

--- a/src/alfred/settings.py
+++ b/src/alfred/settings.py
@@ -124,11 +124,13 @@ experiment.qt_full_screen = _config_parser.getboolean('experiment', 'qt_fullscre
 
 # check if metadata is given correctly
 if not experiment.title:
-    raise ValueError("You need to define an experiment title in config.conf")
+    raise ValueError("You need to define an experiment title in config.conf. Make sure to remove title definition from script.py")
 if not experiment.author:
-    raise ValueError("You need to define an author in config.conf")
+    raise ValueError("You need to define an author in config.conf. Make sure to remove author definition from script.py")
 if not experiment.version:
-    raise ValueError("You need to define an experiment version in config.conf")
+    raise ValueError("You need to define an experiment version in config.conf. Make sure to remove version definition from script.py")
+if not experiment.type:
+    raise ValueError("You need to define an experiment type in config.conf. Make sure to remove type definition from script.py")
 if not (experiment.type == 'qt' or experiment.type == 'web' or experiment.type == 'qt-wk'):
     raise ValueError("experiment.type must be qt, qt-wk or web")
 

--- a/src/alfred/settings.py
+++ b/src/alfred/settings.py
@@ -96,6 +96,10 @@ config_files += [os.path.join(os.getcwd(), 'config.conf')]
 
 config_files = [x for x in config_files if x is not None]
 
+print("\n\n\n")
+print(config_files)
+print("\n\n\n")
+
 # create config parser
 _config_parser = configparser.ConfigParser()
 

--- a/src/alfred/settings.py
+++ b/src/alfred/settings.py
@@ -117,7 +117,7 @@ if not os.path.isabs(general.external_files_dir):
 # experiment
 experiment = _DictObj()
 experiment.title = _config_parser.get('experiment', 'title')
-experiment.author_mail = _config_parser.get('experiment', 'author_mail')
+experiment.author = _config_parser.get('experiment', 'author')
 experiment.version = _config_parser.get('experiment', 'version')
 experiment.type = _config_parser.get('experiment', 'type')
 experiment.qt_full_screen = _config_parser.getboolean('experiment', 'qt_fullscreen')
@@ -125,8 +125,8 @@ experiment.qt_full_screen = _config_parser.getboolean('experiment', 'qt_fullscre
 # check if metadata is given correctly
 if not experiment.title:
     raise ValueError("You need to define an experiment title in config.conf")
-if not experiment.author_mail:
-    raise ValueError("You need to define 'author_mail' in config.conf")
+if not experiment.author:
+    raise ValueError("You need to define an author in config.conf")
 if not experiment.version:
     raise ValueError("You need to define an experiment version in config.conf")
 if not (experiment.type == 'qt' or experiment.type == 'web' or experiment.type == 'qt-wk'):

--- a/src/alfred/settings.py
+++ b/src/alfred/settings.py
@@ -96,10 +96,6 @@ config_files += [os.path.join(os.getcwd(), 'config.conf')]
 
 config_files = [x for x in config_files if x is not None]
 
-print("\n\n\n")
-print(config_files)
-print("\n\n\n")
-
 # create config parser
 _config_parser = configparser.ConfigParser()
 

--- a/src/config.conf
+++ b/src/config.conf
@@ -3,6 +3,9 @@ debug = false
 external_files_dir = .
 
 [experiment]
+title = default
+author_mail = default@author.com
+version = 1.0
 type = web
 qt_fullscreen = false
 web_layout = BaseWebLayout

--- a/src/config.conf
+++ b/src/config.conf
@@ -4,7 +4,7 @@ external_files_dir = .
 
 [experiment]
 title = default
-author_mail = default@author.com
+author = default@author.com
 version = 1.0
 type = web
 qt_fullscreen = false

--- a/src/script.py
+++ b/src/script.py
@@ -7,7 +7,6 @@ Experiment author: Johannes Brachem <jobrachem@posteo.de>
 Description: This is a basic template for an alfred experiment.
 '''
 
-
 #################################
 # - Section 1: Module imports - #
 #################################
@@ -17,16 +16,11 @@ from alfred.section import *
 from alfred.element import *
 from alfred.layout import *
 from alfred.helpmates import *
-
 from alfred import Experiment
 
 #################################################
 # - Section 2: Global variables and functions - #
 #################################################
-EXP_TYPE = "web"
-EXP_NAME = "template"
-EXP_VERSION = "0.1"
-EXP_AUTHOR_MAIL = "your@email.com"
 
 #################################
 # - Section 3: Custom classes - #
@@ -40,7 +34,7 @@ EXP_AUTHOR_MAIL = "your@email.com"
 class Script(object):
 
     def generate_experiment(self):
-        exp = Experiment(EXP_TYPE, EXP_NAME, EXP_VERSION, EXP_AUTHOR_MAIL)
+        exp = Experiment()
 
         # --- Page 1 --- #
         # -------------------------------------- #


### PR DESCRIPTION
## Experiment metadata (title, version, type and author)
1. New experiment metadata field author. You must define an experiment author in `config.conf`. **If you use local alfred experiments that save data online to a mortimer database, you have to use your mortimer username**. Otherwise, you will not be able to access your data from Mortimer.
1. Experiment 'name' was renamed to experiment 'title'
1. The title, version and type of an experiment are now defined in `config.conf` instead of `script.py`
    + This means, no more configuration parameters need to be defined in your `script.py`
    + Experiment type is now defined only once (in previous versions, it was defined in both `script.py` and `config.conf`
    + If a users supplies metadata according to the style of previous versions, a SyntaxError with an informative error message is thrown.

## Experiment ID and session ID
Previously, there was only and Experiment._uuid, which really was a session id, because it is a different id for each experiment startup.

For use in Mortimer, it is convenient though to have both: A unique id for an experiment, and a unique id for a session.

Thus, the Experiment._uuid is now an experiment identifier when used with mortimer, and the Experiment._sessionid is (always) a session identifier. When alfred is used locally, the Experiment._uuid does not function as a unique identifier, in this case it still is a session id. Mortimer uses the Experiment.update() method to set the Experiment._uuid.