### PR TITLE
Renaming

### DIFF
--- a/src/alfred/_core.py
+++ b/src/alfred/_core.py
@@ -10,7 +10,7 @@ import os.path
 from uuid import uuid4
 
 
-class PageCore(object):
+class ContentCore(object):
     def __init__(self, tag=None, uid=None, tag_and_uid=None, is_jumpable=True, jumptext=None,
                  title=None, subtitle=None, statustext=None,
                  should_be_shown_filter_function=None, **kwargs):

--- a/src/alfred/element.py
+++ b/src/alfred/element.py
@@ -113,7 +113,7 @@ class Element(object):
 
     def added_to_page(self, q):
         from . import page
-        if not isinstance(q, page.Page):
+        if not isinstance(q, page.PageCore):
             raise TypeError()
 
         self._page = q

--- a/src/alfred/page.py
+++ b/src/alfred/page.py
@@ -10,7 +10,7 @@ from builtins import object
 from abc import ABCMeta, abstractproperty
 import time
 
-from ._core import PageCore
+from ._core import ContentCore
 from .exceptions import AlfredError
 from . import element, alfredlog
 from .element import Element, WebElementInterface, TextElement, ExperimenterMessages
@@ -22,7 +22,7 @@ from functools import reduce
 logger = alfredlog.getLogger(__name__)
 
 
-class Page(PageCore):
+class PageCore(ContentCore):
     def __init__(self, minimum_display_time=0, minimum_display_time_msg=None, **kwargs):
         self._minimum_display_time = minimum_display_time
         if settings.debugmode and settings.debug.disable_minimum_display_time:
@@ -33,13 +33,13 @@ class Page(PageCore):
         self._is_closed = False
         self._show_corrective_hints = False
 
-        super(Page, self).__init__(**kwargs)
+        super(PageCore, self).__init__(**kwargs)
 
     def added_to_experiment(self, experiment):
         if not isinstance(self, WebPageInterface):
             raise TypeError('%s must be an instance of %s' % (self.__class__.__name__, WebPageInterface.__name__))
 
-        super(Page, self).added_to_experiment(experiment)
+        super(PageCore, self).added_to_experiment(experiment)
 
     @property
     def show_thumbnail(self):
@@ -59,7 +59,7 @@ class Page(PageCore):
 
     @property
     def data(self):
-        data = super(Page, self).data
+        data = super(PageCore, self).data
         data.update(self._data)
         return data
 
@@ -169,7 +169,7 @@ class WebPageInterface(with_metaclass(ABCMeta, object)):
         pass
 
 
-class CoreCompositePage(Page):
+class CoreCompositePage(PageCore):
     def __init__(self, elements=None, **kwargs):
         super(CoreCompositePage, self).__init__(**kwargs)
 
@@ -319,8 +319,11 @@ class WebCompositePage(CoreCompositePage, WebPageInterface):
 class CompositePage(WebCompositePage):
     pass
 
+class Page(WebCompositePage):
+    pass
 
-class PagePlaceholder(Page, WebPageInterface):
+
+class PagePlaceholder(PageCore, WebPageInterface):
     def __init__(self, ext_data={}, **kwargs):
         super(PagePlaceholder, self).__init__(**kwargs)
 
@@ -332,7 +335,7 @@ class PagePlaceholder(Page, WebPageInterface):
 
     @property
     def data(self):
-        data = super(Page, self).data
+        data = super(PageCore, self).data
         data.update(self._ext_data)
         return data
 

--- a/src/alfred/section.py
+++ b/src/alfred/section.py
@@ -11,13 +11,13 @@ from . import alfredlog
 from functools import reduce
 logger = alfredlog.getLogger(__name__)
 
-from ._core import PageCore, Direction
-from .page import Page, HeadOpenSectionCantClose
+from ._core import ContentCore, Direction
+from .page import PageCore, HeadOpenSectionCantClose
 from .exceptions import MoveError
 from random import shuffle
 
 
-class Section(PageCore):
+class Section(ContentCore):
 
     def __init__(self, **kwargs):
         super(Section, self).__init__(**kwargs)
@@ -52,7 +52,7 @@ class Section(PageCore):
         if isinstance(self._page_list[self._currentPageIndex], Section) and self._page_list[self._currentPageIndex].current_title is not None:
             return self._page_list[self._currentPageIndex].current_title
 
-        if isinstance(self._page_list[self._currentPageIndex], Page) and self._page_list[self._currentPageIndex].title is not None:
+        if isinstance(self._page_list[self._currentPageIndex], PageCore) and self._page_list[self._currentPageIndex].title is not None:
             return self._page_list[self._currentPageIndex].title
 
         return self.title
@@ -62,7 +62,7 @@ class Section(PageCore):
         if isinstance(self._page_list[self._currentPageIndex], Section) and self._page_list[self._currentPageIndex].current_subtitle is not None:
             return self._page_list[self._currentPageIndex].current_subtitle
 
-        if isinstance(self._page_list[self._currentPageIndex], Page) and self._page_list[self._currentPageIndex].subtitle is not None:
+        if isinstance(self._page_list[self._currentPageIndex], PageCore) and self._page_list[self._currentPageIndex].subtitle is not None:
             return self._page_list[self._currentPageIndex].subtitle
 
         return self.subtitle
@@ -72,12 +72,12 @@ class Section(PageCore):
         if isinstance(self._page_list[self._currentPageIndex], Section) and self._page_list[self._currentPageIndex].current_status_text is not None:
             return self._page_list[self._currentPageIndex].current_status_text
 
-        if isinstance(self._page_list[self._currentPageIndex], Page) and self._page_list[self._currentPageIndex].statustext is not None:
+        if isinstance(self._page_list[self._currentPageIndex], PageCore) and self._page_list[self._currentPageIndex].statustext is not None:
             return self._page_list[self._currentPageIndex].statustext
 
         return self.statustext
 
-    @PageCore.should_be_shown.getter
+    @ContentCore.should_be_shown.getter
     def should_be_shown(self):
         '''return true wenn should_be_shown nicht auf False gesetzt wurde und mindestens eine Frage angezeigt werden will'''
         return super(Section, self).should_be_shown and reduce(lambda b, q_core: b or q_core.should_be_shown, self._page_list, False)
@@ -113,7 +113,7 @@ class Section(PageCore):
                     jump_item[0].append(i)
                     jump_item[0].reverse()
                     jumplist.append(jump_item)
-            elif isinstance(self._page_list[i], Page) and self._page_list[i].is_jumpable:
+            elif isinstance(self._page_list[i], PageCore) and self._page_list[i].is_jumpable:
                 jumplist.append(([i], self._page_list[i].jumptext, self._page_list[i]))
 
         return jumplist
@@ -257,7 +257,7 @@ class Section(PageCore):
         if not self._page_list[pos_list[0]].should_be_shown:
             raise MoveError("Die Angegebene Position kann nicht angezeigt werden")
 
-        if isinstance(self._page_list[pos_list[0]], Page) and 1 < len(pos_list):
+        if isinstance(self._page_list[pos_list[0]], PageCore) and 1 < len(pos_list):
             raise MoveError("pos_list spezifiziert genauer als moeglich.")
 
         if isinstance(self._core_page_at_index, Section):
@@ -291,7 +291,7 @@ class HeadOpenSection(Section):
 
         # direction is Direction.FORWARD
 
-        if isinstance(self._core_page_at_index, Page):
+        if isinstance(self._core_page_at_index, PageCore):
             HeadOpenSection._set_show_corrective_hints(self._core_page_at_index, True)
             return self._core_page_at_index.allow_closing and super(HeadOpenSection, self).allow_leaving(direction)
         else:  # currentCorePage is Group
@@ -310,7 +310,7 @@ class HeadOpenSection(Section):
                 not self._core_page_at_index.can_move_forward and \
                 not HeadOpenSection._allow_closing_all_child_pages(self._core_page_at_index):
             return True
-        elif isinstance(self._core_page_at_index, Page) and \
+        elif isinstance(self._core_page_at_index, PageCore) and \
                 not self._core_page_at_index.allow_closing:
             return True
         else:
@@ -335,7 +335,7 @@ class HeadOpenSection(Section):
         '''
         '''
         if self._maxPageIndex == self._currentPageIndex:
-            if isinstance(self._core_page_at_index, Page):
+            if isinstance(self._core_page_at_index, PageCore):
                 self._core_page_at_index.close_page()
 
             elif not self._core_page_at_index.can_move_forward:  # self._core_page_at_index is instance of Section and at the last item
@@ -362,7 +362,7 @@ class HeadOpenSection(Section):
     def leave(self, direction):
         if direction == Direction.FORWARD:
             logger.debug("Leaving HeadOpenSection direction forward. closing last page.", self._experiment)
-            if isinstance(self._core_page_at_index, Page):
+            if isinstance(self._core_page_at_index, PageCore):
                 self._core_page_at_index.close_page()
             else:
                 HeadOpenSection._close_child_pages(self._core_page_at_index)
@@ -384,14 +384,14 @@ class HeadOpenSection(Section):
     @staticmethod
     def _close_child_pages(section):
         for item in section._page_list:
-            if isinstance(item, Page):
+            if isinstance(item, PageCore):
                 item.close_page()
             else:
                 HeadOpenSection._close_child_pages(item)
 
     @staticmethod
     def _set_show_corrective_hints(corePage, b):
-        if isinstance(corePage, Page):
+        if isinstance(corePage, PageCore):
             corePage.show_corrective_hints = b
         else:
             section = corePage

--- a/src/config.conf
+++ b/src/config.conf
@@ -6,7 +6,7 @@ external_files_dir = .
 title = default
 author = default@author.com
 version = 1.0
-type = qt-wk
+type = web
 qt_fullscreen = false
 web_layout = BaseWebLayout
 

--- a/src/script.py
+++ b/src/script.py
@@ -28,7 +28,7 @@ def generate_experiment(self):
     exp = Experiment()
 
     # --- Page 1 --- #
-    page01 = WebCompositePage(title="Hello, world!")
+    page01 = Page(title="Hello, world!")
     el = TextElement("test")
     page01.append(el)
 

--- a/src/script.py
+++ b/src/script.py
@@ -25,16 +25,19 @@ from alfred import Experiment
 
 
 def generate_experiment(self):
+    exp = Experiment()
 
     # --- Page 1 --- #
     page01 = WebCompositePage(title="Hello, world!")
+    el = TextElement("test")
+    page01.append(el)
 
     # Sections
     main = SegmentedSection()
     main.append_items(page01)
 
     # Initialize and fill experiment
-    exp = Experiment()
+    
     exp.append(main)
 
     return exp


### PR DESCRIPTION
A little usability improvement: Users can now just use `Page` instead of `WebCompositePage`. `WebCompositePage` still works though. 