### PR TITLE
rename PageController.change_to_finished_section

### DIFF
--- a/src/alfred/__init__.py
+++ b/src/alfred/__init__.py
@@ -163,7 +163,7 @@ class Experiment(object):
 
     def finish(self):
         '''
-        Beendet das Experiment. Ruft  :meth:`page_controller.PageController.change_to_finished_group` auf und setzt **self._finished** auf *True*.
+        Beendet das Experiment. Ruft  :meth:`page_controller.PageController.change_to_finished_section` auf und setzt **self._finished** auf *True*.
 
         '''
         if self._finished:
@@ -171,7 +171,7 @@ class Experiment(object):
             return
         logger.info("Experiment.finish() called. Session is finishing.", self)
         self._finished = True
-        self._page_controller.change_to_finished_group()
+        self._page_controller.change_to_finished_section()
 
         # run saving_agent_controller
         self._saving_agent_controller.run_saving_agents(99)

--- a/src/alfred/page_controller.py
+++ b/src/alfred/page_controller.py
@@ -1,10 +1,10 @@
 # -*- coding:utf-8 -*-
 
-'''
+"""
 .. moduleauthor:: Paul Wiemann <paulwiemann@gmail.com>
 
 In *page_controller* wird die Basisklasse *PageController* bereit gestellt.
-'''
+"""
 from __future__ import absolute_import
 from builtins import object
 from alfred._core import Direction
@@ -12,26 +12,48 @@ from alfred._core import Direction
 from .section import Section
 from .page import CompositePage, WebCompositePage
 from .element import TextElement, WebExitEnabler
+from . import alfredlog
+
+logger = alfredlog.getLogger("alfred")
 
 
 class PageController(object):
-    '''
+    """
     | PageController stellt die obersten Fragengruppen des Experiments (*rootSection* und *finishedSection*)
     | bereit und ermöglicht den Zugriff auf auf deren Methoden und Attribute.
-    '''
+    """
 
     def __init__(self, experiment):
         self._experiment = experiment
 
-        self._rootSection = Section(tag='rootSection')
+        self._rootSection = Section(tag="rootSection")
         self._rootSection.added_to_experiment(experiment)
 
-        self._finishedSection = Section(tag='finishedSection', title='Experiment beendet')
+        self._finishedSection = Section(
+            tag="finishedSection", title="Experiment beendet"
+        )
 
-        if self._experiment.type == 'qt':
-            self._finishedSection.append(CompositePage(elements=[TextElement(u'Das Experiment ist nun beendet. Vielen Dank für die Teilnahme.')]))
+        if self._experiment.type == "qt":
+            self._finishedSection.append(
+                CompositePage(
+                    elements=[
+                        TextElement(
+                            u"Das Experiment ist nun beendet. Vielen Dank für die Teilnahme."
+                        )
+                    ]
+                )
+            )
         else:
-            self._finishedSection.append(WebCompositePage(elements=[TextElement(u'Das Experiment ist nun beendet. Vielen Dank für die Teilnahme.'), WebExitEnabler()]))
+            self._finishedSection.append(
+                WebCompositePage(
+                    elements=[
+                        TextElement(
+                            u"Das Experiment ist nun beendet. Vielen Dank für die Teilnahme."
+                        ),
+                        WebExitEnabler(),
+                    ]
+                )
+            )
 
         self._finishedSection.added_to_experiment(experiment)
 
@@ -39,14 +61,26 @@ class PageController(object):
         self._finishedPageAdded = False
 
     def __getattr__(self, name):
-        '''
+        """
         Die Funktion reicht die aufgerufenen Attribute und Methoden an die oberen Fragengruppen weiter.
 
         Achtung: Nur bei Items in der switch_list wird zwischen rootSection und finishedSection unterschieden.
-        '''
-        switch_list = ['current_page', 'current_title', 'current_subtitle', 'current_status_text', 'should_be_shown',
-                       'jumplist', 'can_move_backward', 'can_move_forward', 'move_backward', 'move_forward', 'move_to_first',
-                       'move_to_last', 'move_to_position']
+        """
+        switch_list = [
+            "current_page",
+            "current_title",
+            "current_subtitle",
+            "current_status_text",
+            "should_be_shown",
+            "jumplist",
+            "can_move_backward",
+            "can_move_forward",
+            "move_backward",
+            "move_forward",
+            "move_to_first",
+            "move_to_last",
+            "move_to_position",
+        ]
         try:
             if name in switch_list:
                 if self._finished:
@@ -60,30 +94,37 @@ class PageController(object):
             # raise AttributeError("'%s' has no Attribute '%s'" % (self.__class__.__name__, name))
 
     def append_item_to_finish_section(self, item):
-        '''
+        """
         :param item: Element vom Typ Page oder Section
 
         .. todo:: Ist diese Funktion überhaupt nötig, wenn die finishedSection in init bereits erstellt wird?
-        '''
+        """
         if not self._finishedPageAdded:
             self._finishedPageAdded = True
-            self._finishedSection = Section(tag='finishedSection')
+            self._finishedSection = Section(tag="finishedSection")
             self._finishedSection.added_to_experiment(self._experiment)
         self._finishedSection.append(item)
 
     def added_to_experiment(self, exp):
-        '''
+        """
         Ersetzt __getattr___ und erreicht so sowohl die rootSection als auch die finishedSection
 
         :param exp: Objekt vom Typ Experiment
-        '''
+        """
         self._experiment = exp
         self._rootSection.added_to_experiment(exp)
         self._finishedSection.added_to_experiment(exp)
 
-    def change_to_finished_group(self):
+    def change_to_finished_section(self):
         self._finished = True
         self._rootSection.leave(Direction.FORWARD)
         self._finishedSection.enter()
         self._finishedSection.move_to_first()
         self._experiment.user_interface_controller.layout.finish_disabled = True
+
+    def change_to_finished_group(self):
+        logger.warning(
+            "PageController.change_to_finished_group() is deprecated. Use PageController.change_to_finished_section() instead.",
+            experiment=self._experiment,
+        )
+        self.change_to_finished_section()


### PR DESCRIPTION
This was a missed function call from the old naming scheme. Generally, it will not affect the user in most cases, but it still exists as a deprecated function, logging a warning now.