### PR TITLE
Release v1.0.7

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# alfred v1.0.7
+
+## Security improvements
+
+* We further increased data protection and data security through an improved handling of access to the alfred database from inside web experiments deployed via  mortimer.
+* Updated handling of local experiments: You can now specify an optional `auth_source` parameter in the `mongo_saving_agent` section in `config.conf`. The parameter will be passed to the `authSource` parameter of `pymongo.MongoClient` in the initialisation of the saving agent. This allows you to use database accounts that user other databases than "admin" for authentication, which offers greater security.
+
+## Smaller changes
+
+* Disabled the logging of debug messages for the `Page.on_showing()` method. This led to overcrowded logs.
+
 # alfred v1.0.6
 
 ## Encryption

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 from setuptools.command.install import install as dist_install
 
 name = 'alfred'
-version = '1.0.6'  # major.minor[.patch[sub] e.g. 0.1.0 first experimental version, 1.0.1b2 second beta release of the first patch of 1.0
+version = '1.0.7'  # major.minor[.patch[sub] e.g. 0.1.0 first experimental version, 1.0.1b2 second beta release of the first patch of 1.0
 desc = 'alfred : a library for rapid experiment development'
 author = 'Christian Treffenstaedt, Paul Wiemann, Johannes Brachem'
 author_email = 'treffenstaedt@psych.uni-goettingen.de'

--- a/src/alfred/__init__.py
+++ b/src/alfred/__init__.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 
 from builtins import object
 
-__version__ = "1.0.6"  # will be saved in the data set
+__version__ = "1.0.7"  # will be saved in the data set
 
 # configure alfred logger
 #

--- a/src/alfred/__init__.py
+++ b/src/alfred/__init__.py
@@ -98,6 +98,8 @@ class Experiment(object):
         if not self._exp_id:
             raise ValueError("You need to specify an experiment ID.")
 
+        self.__db_cred = config.get("db_cred", None)
+
         # Set encryption key
         if config and config["encryption_key"]:
             self._encryptor = Fernet(config["encryption_key"])
@@ -160,7 +162,7 @@ class Experiment(object):
             ValueError("unknown type: '%s'" % self._type)
 
         self._data_manager = DataManager(self)
-        self._saving_agent_controller = SavingAgentController(self)
+        self._saving_agent_controller = SavingAgentController(self, db_cred=self.__db_cred)
 
         self._condition = ""
         self._session = ""

--- a/src/alfred/__init__.py
+++ b/src/alfred/__init__.py
@@ -222,10 +222,6 @@ class Experiment(object):
         return self._alfred_version
 
     @property
-    def alfred_version(self):
-        return self._alfred_version
-
-    @property
     def author(self):
         """
         Achtung: *read-only*
@@ -266,10 +262,6 @@ class Experiment(object):
     def start_timestamp(self):
         return self._start_timestamp
     
-    @property
-    def start_time(self):
-        return self._start_time
-
     @property
     def start_time(self):
         return self._start_time

--- a/src/alfred/__init__.py
+++ b/src/alfred/__init__.py
@@ -132,6 +132,7 @@ class Experiment(object):
         self._page_controller = PageController(self)
 
         # Determine web layout if necessary
+        # pylint: disable=no-member
         if self._type == "web" or self._type == "qt-wk":
             if custom_layout:
                 web_layout = custom_layout

--- a/src/alfred/__init__.py
+++ b/src/alfred/__init__.py
@@ -98,7 +98,8 @@ class Experiment(object):
         if not self._exp_id:
             raise ValueError("You need to specify an experiment ID.")
 
-        self.__db_cred = config.get("db_cred", None)
+        if config is not None:
+            self.__db_cred = config.get("db_cred", None)
 
         # Set encryption key
         if config and config["encryption_key"]:

--- a/src/alfred/__init__.py
+++ b/src/alfred/__init__.py
@@ -100,6 +100,8 @@ class Experiment(object):
 
         if config is not None:
             self.__db_cred = config.get("db_cred", None)
+        else:
+            self.__db_cred = None
 
         # Set encryption key
         if config and config["encryption_key"]:

--- a/src/alfred/element.py
+++ b/src/alfred/element.py
@@ -27,28 +27,30 @@ TripleBarChartElement Display a chart with three different bars (temporary)
 ===================== ===============================================================
 
 """
-from __future__ import division
-from __future__ import absolute_import
+from __future__ import absolute_import, division
+
+import json
+import random
+import re
+import string
+from abc import ABCMeta, abstractproperty
+from builtins import object, range, str
+from functools import reduce
+from uuid import uuid4
 
 from future import standard_library
-from functools import reduce
-
-standard_library.install_aliases()
-from builtins import str
-from builtins import range
+from future.utils import with_metaclass
+from jinja2 import Environment, PackageLoader, Template
 from past.utils import old_div
-from builtins import object
-import re, string, random, json
-from jinja2 import Template, PackageLoader, Environment
-from uuid import uuid4
-from abc import ABCMeta, abstractproperty
 
-from .exceptions import AlfredError
-from ._helper import fontsize_converter, alignment_converter, is_url
 import alfred.settings as settings
 
 from . import alfredlog
-from future.utils import with_metaclass
+from ._helper import alignment_converter, fontsize_converter, is_url
+from .exceptions import AlfredError
+
+standard_library.install_aliases()
+
 
 logger = alfredlog.getLogger("alfred")
 
@@ -456,9 +458,6 @@ class CodeElement(Element, WebElementInterface):
     @text.setter
     def text(self, text):
         self._text = text
-        if self._text_label:
-            self._text_label.set_text(self._text)
-            self._text_label.repaint()
 
     @property
     def web_widget(self):
@@ -2792,8 +2791,8 @@ class WebVideoElement(Element, WebElementInterface):
         TODO: Add docstring
         """
         super(WebVideoElement, self).__init__(**kwargs)
-        # load template
-        self._template = jinja_env.get_template("WebVideoElement.html")
+
+        self._template = None
 
         # if single source is given
         self._source = source
@@ -2867,6 +2866,9 @@ class WebVideoElement(Element, WebElementInterface):
         self._attributes = " ".join(attr)
 
     def prepare_web_widget(self):
+        # load template
+        self._template = jinja_env.get_template("WebVideoElement.html")
+
         # prepare attributes
         self.prepare_attributes()
 
@@ -2904,7 +2906,7 @@ class WebVideoElement(Element, WebElementInterface):
             self._web_m_video_url = self._page._experiment.user_interface_controller.add_static_file(
                 self._web_m_path, content_type="video/webm"
             )
-            self._urls.append(self.web_m_video_url)
+            self._urls.append(self._web_m_video_url)
         # -------------------------------------------- #
 
     @property

--- a/src/alfred/page.py
+++ b/src/alfred/page.py
@@ -107,7 +107,7 @@ class PageCore(ContentCore):
         elif self._run_on_showing == 'always':
             self.on_showing_widget()
             self.on_showing()
-            self._log.append(('debug', 'The current page executes the "on_showing" method every time the page is shown. If you want to turn this behavior off, please use "run_on_showing=\'once\'" in the page initialisation.'))
+            # self._log.append(('debug', 'The current page executes the "on_showing" method every time the page is shown. If you want to turn this behavior off, please use "run_on_showing=\'once\'" in the page initialisation.'))
 
 
         self._has_been_shown = True

--- a/src/alfred/page.py
+++ b/src/alfred/page.py
@@ -129,8 +129,8 @@ class PageCore(ContentCore):
         elif self._run_on_showing == 'always':
             self.on_hiding_widget()
             self.on_hiding()
-            self._log.append(('debug',
-                             'The current page executes the "on_hiding" method every time the page is hidden. If you want to turn this behavior off, please use "run_on_hiding=\'once\'" in the page initialisation.'))
+            # self._log.append(('debug',
+            #                  'The current page executes the "on_hiding" method every time the page is hidden. If you want to turn this behavior off, please use "run_on_hiding=\'once\'" in the page initialisation.'))
 
         self._has_been_hidden = True
         self.print_log()

--- a/src/alfred/saving_agent.py
+++ b/src/alfred/saving_agent.py
@@ -108,8 +108,8 @@ class SavingAgentController(object):
             raise SavingAgentException("Critical initialization abort! Error while adding failure SavingAgent: %s" % e)
 
         # add saving agents from settings
-
-        if self._experiment.settings.general.runs_on_mortimer:
+        morti = dict(self._experiment.settings.general).get("runs_on_mortimer", None)
+        if morti and morti != "false" :
             try:
                 host = self._db_cred["host"] + ":" + str(self._db_cred["port"])
                 agent = MongoSavingAgent(
@@ -163,7 +163,8 @@ class SavingAgentController(object):
                     self._experiment.settings.mongo_saving_agent.use_ssl,
                     self._experiment.settings.mongo_saving_agent.ca_file_path,
                     self._experiment.settings.mongo_saving_agent.level,
-                    self._experiment
+                    self._experiment,
+                    self._experiment.settings.mongo_saving_agent.auth_source
                 )
                 self.add_saving_agent(agent)
             except Exception as e:

--- a/src/alfred/saving_agent.py
+++ b/src/alfred/saving_agent.py
@@ -111,8 +111,9 @@ class SavingAgentController(object):
 
         if self._experiment.settings.general.runs_on_mortimer:
             try:
+                host = self._db_cred["host"] + ":" + self._db_cred["port"]
                 agent = MongoSavingAgent(
-                    self._db_cred["host"],
+                    host,
                     self._db_cred["db"],
                     self._db_cred["collection"],
                     self._db_cred["user"],

--- a/src/alfred/saving_agent.py
+++ b/src/alfred/saving_agent.py
@@ -120,7 +120,8 @@ class SavingAgentController(object):
                     self._db_cred["use_ssl"],
                     self._db_cred["ca_file_path"],
                     self._db_cred["activation_level"],
-                    self._experiment
+                    self._experiment,
+                    self._db_cred["db"]
                 )
                 self.add_saving_agent(agent)
             except Exception as e:
@@ -423,17 +424,17 @@ class CouchDBSavingAgent(SavingAgent):
 
 
 class MongoSavingAgent(SavingAgent):
-    def __init__(self, host, database, collection, user, password, use_ssl, ca_file_path, activation_level=10, experiment=None):
+    def __init__(self, host, database, collection, user, password, use_ssl, ca_file_path, activation_level=10, experiment=None, auth_source="admin"):
         super(MongoSavingAgent, self).__init__(activation_level, experiment)
 
         if use_ssl and os.path.isfile(ca_file_path):  # if self-signed ssl cert is used
             self._mc = pymongo.MongoClient(host=host, username=user, password=password,
-                                           ssl=use_ssl, ssl_ca_certs=ca_file_path)
+                                           ssl=use_ssl, ssl_ca_certs=ca_file_path, authSource=auth_source)
         elif use_ssl:  # if commercial ssl certificate is used
             self._mc = pymongo.MongoClient(host=host, username=user, password=password,
-                                           ssl=use_ssl)
+                                           ssl=use_ssl, authSource=auth_source)
         else:  # if no ssl encryption is used
-            self._mc = pymongo.MongoClient(host=host, username=user, password=password)
+            self._mc = pymongo.MongoClient(host=host, username=user, password=password, authSource=auth_source)
 
         self._db = self._mc[database]
         # if not self._db.authenticate(user, password):

--- a/src/alfred/saving_agent.py
+++ b/src/alfred/saving_agent.py
@@ -31,7 +31,7 @@ def _save_worker():
     try:
         while True:
             try:
-                (i, data_time, level, snapshot_id, event, data, sac) = _queue.get_nowait()
+                (_, data_time, level, _, event, data, sac) = _queue.get_nowait()
             except queue.Empty:
                 break
             sac._do_saving(data, data_time, level)
@@ -397,7 +397,7 @@ class LocalSavingAgent(SavingAgent):
 
 class CouchDBSavingAgent(SavingAgent):
     def __init__(self, url, database, activation_level=10, experiment=None):
-        import couchdb
+        import couchdb # pylint: disable=import-error
 
         super(CouchDBSavingAgent, self).__init__(activation_level, experiment)
 

--- a/src/alfred/saving_agent.py
+++ b/src/alfred/saving_agent.py
@@ -111,7 +111,7 @@ class SavingAgentController(object):
 
         if self._experiment.settings.general.runs_on_mortimer:
             try:
-                host = self._db_cred["host"] + ":" + self._db_cred["port"]
+                host = self._db_cred["host"] + ":" + str(self._db_cred["port"])
                 agent = MongoSavingAgent(
                     host,
                     self._db_cred["db"],

--- a/src/alfred/settings.py
+++ b/src/alfred/settings.py
@@ -195,6 +195,7 @@ class ExperimentSpecificSettings(object):
         self.mongo_saving_agent.login_from_env = config_parser.getboolean('mongo_saving_agent', 'login_from_env')
         self.mongo_saving_agent.user = config_parser.get('mongo_saving_agent', 'user')
         self.mongo_saving_agent.password = config_parser.get('mongo_saving_agent', 'password')
+        self.mongo_saving_agent.auth_source = config_parser.get('mongo_saving_agent', 'auth_shource', fallback="alfred")
 
         if self.mongo_saving_agent.use and self.mongo_saving_agent.login_from_env:
             self.mongo_saving_agent.user, self.mongo_saving_agent.password = decrypter.decrypt_login(from_env=True)

--- a/src/alfred/settings.py
+++ b/src/alfred/settings.py
@@ -7,16 +7,14 @@ experimentspezifische Einstellungen vorzunehmen, die dann unter
 Experiment.settings abgefragt werden können.
 """
 
+import codecs, configparser, io, os, sys
+from builtins import object, str
+
 from future import standard_library
+
+from ._helper import Decrypter, _DictObj
+
 standard_library.install_aliases()
-from builtins import str
-from builtins import object
-import sys
-import os
-import configparser
-import codecs
-import io
-from ._helper import _DictObj, Decrypter
 
 
 def _package_path():
@@ -61,10 +59,13 @@ for config_file in config_files:
 # general
 general = _DictObj()
 general.debug = _config_parser.getboolean('general', 'debug')
-debugmode = general.debug
+general.runs_on_mortimer = _config_parser.getboolean('general', 'runs_on_mortimer', fallback=False)
 general.external_files_dir = _config_parser.get('general', 'external_files_dir')
+
 if not os.path.isabs(general.external_files_dir):
     general.external_files_dir = os.path.join(os.getcwd(), general.external_files_dir)
+
+debugmode = general.debug
 
 # metadata
 metadata = _DictObj()

--- a/src/alfred/templates/elements/WebVideoElement.html
+++ b/src/alfred/templates/elements/WebVideoElement.html
@@ -1,9 +1,8 @@
-{% extends '_element_base.html' %}
-{% block element %}
+<div class="{{ element_class }}" style="{{ alignment }}">
     <video {{ attributes }} playsinline controlsList="nodownload">
         {% for url in urls %}
         <source src="{{ url }}">
         {% endfor %}
         Your browser does not support the video tag.
     </video>
-{% endblock %}
+</div>

--- a/src/config.conf
+++ b/src/config.conf
@@ -1,6 +1,7 @@
 [general]
 debug = false
 external_files_dir = 
+runs_on_mortimer = false
 
 [metadata]
 title = default


### PR DESCRIPTION
## Security improvements

* We further increased data protection and data security through an improved handling of access to the alfred database from inside web experiments deployed via  mortimer.
* Updated handling of local experiments: You can now specify an optional `auth_source` parameter in the `mongo_saving_agent` section in `config.conf`. The parameter will be passed to the `authSource` parameter of `pymongo.MongoClient` in the initialisation of the saving agent. This allows you to use database accounts that user other databases than "admin" for authentication, which offers greater security.

## Smaller changes

* Disabled the logging of debug messages for the `Page.on_showing()` method. This led to overcrowded logs.