### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/).
 <!-- and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). -->
 
+## alfred3 v2.1.1 (Released 2021-05-18)
+
+### Changed v2.1.1
+
+- We now save a basic skeleton of an experiment's data directly on 
+  initializing a session. While this introduces a short delay (max 1s)
+  upon starting an experiment, this makes it easier for plugins such
+  as `alfred3_interact` to rely on certain data being available during 
+  setup.
+
 ## alfred3 v2.1.0 (Released 2021-05-14)
 
 ### Added v2.1.0

--- a/docs/source/generated/alfred3.element.action.SubmittingButtons.js_template.rst
+++ b/docs/source/generated/alfred3.element.action.SubmittingButtons.js_template.rst
@@ -1,0 +1,6 @@
+SubmittingButtons.js\_template
+====================================================
+
+.. currentmodule:: alfred3.element.action
+
+.. autoattribute:: SubmittingButtons.js_template

--- a/docs/source/generated/alfred3.element.action.SubmittingButtons.rst
+++ b/docs/source/generated/alfred3.element.action.SubmittingButtons.rst
@@ -1,4 +1,4 @@
-SubmittingButtons
+﻿SubmittingButtons
 ========================================
 
 .. currentmodule:: alfred3.element.action
@@ -88,6 +88,7 @@ SubmittingButtons
          ~SubmittingButtons.hint_manager
          ~SubmittingButtons.input
          ~SubmittingButtons.js_code
+         ~SubmittingButtons.js_template
          ~SubmittingButtons.js_urls
          ~SubmittingButtons.labels
          ~SubmittingButtons.layout

--- a/docs/source/generated/alfred3.element.display.Audio.bottomlab.rst
+++ b/docs/source/generated/alfred3.element.display.Audio.bottomlab.rst
@@ -1,0 +1,6 @@
+Audio.bottomlab
+=======================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Audio.bottomlab

--- a/docs/source/generated/alfred3.element.display.Audio.labels.rst
+++ b/docs/source/generated/alfred3.element.display.Audio.labels.rst
@@ -1,0 +1,6 @@
+Audio.labels
+====================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Audio.labels

--- a/docs/source/generated/alfred3.element.display.Audio.layout.rst
+++ b/docs/source/generated/alfred3.element.display.Audio.layout.rst
@@ -1,0 +1,6 @@
+Audio.layout
+====================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Audio.layout

--- a/docs/source/generated/alfred3.element.display.Audio.leftlab.rst
+++ b/docs/source/generated/alfred3.element.display.Audio.leftlab.rst
@@ -1,0 +1,6 @@
+Audio.leftlab
+=====================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Audio.leftlab

--- a/docs/source/generated/alfred3.element.display.Audio.rightlab.rst
+++ b/docs/source/generated/alfred3.element.display.Audio.rightlab.rst
@@ -1,0 +1,6 @@
+Audio.rightlab
+======================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Audio.rightlab

--- a/docs/source/generated/alfred3.element.display.Audio.rst
+++ b/docs/source/generated/alfred3.element.display.Audio.rst
@@ -1,4 +1,4 @@
-Audio
+﻿Audio
 =============================
 
 .. currentmodule:: alfred3.element.display
@@ -49,6 +49,7 @@ Audio
 
       
          ~Audio.base_template
+         ~Audio.bottomlab
          ~Audio.converted_width
          ~Audio.css_class_container
          ~Audio.css_class_element
@@ -62,14 +63,19 @@ Audio
          ~Audio.font_size
          ~Audio.js_code
          ~Audio.js_urls
+         ~Audio.labels
+         ~Audio.layout
+         ~Audio.leftlab
          ~Audio.name
          ~Audio.page
          ~Audio.position
+         ~Audio.rightlab
          ~Audio.section
          ~Audio.short_tree
          ~Audio.should_be_shown
          ~Audio.showif
          ~Audio.template_data
+         ~Audio.toplab
          ~Audio.tree
          ~Audio.web_widget
          ~Audio.width

--- a/docs/source/generated/alfred3.element.display.Audio.toplab.rst
+++ b/docs/source/generated/alfred3.element.display.Audio.toplab.rst
@@ -1,0 +1,6 @@
+Audio.toplab
+====================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Audio.toplab

--- a/docs/source/generated/alfred3.element.display.Image.bottomlab.rst
+++ b/docs/source/generated/alfred3.element.display.Image.bottomlab.rst
@@ -1,0 +1,6 @@
+Image.bottomlab
+=======================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Image.bottomlab

--- a/docs/source/generated/alfred3.element.display.Image.labels.rst
+++ b/docs/source/generated/alfred3.element.display.Image.labels.rst
@@ -1,0 +1,6 @@
+Image.labels
+====================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Image.labels

--- a/docs/source/generated/alfred3.element.display.Image.layout.rst
+++ b/docs/source/generated/alfred3.element.display.Image.layout.rst
@@ -1,0 +1,6 @@
+Image.layout
+====================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Image.layout

--- a/docs/source/generated/alfred3.element.display.Image.leftlab.rst
+++ b/docs/source/generated/alfred3.element.display.Image.leftlab.rst
@@ -1,0 +1,6 @@
+Image.leftlab
+=====================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Image.leftlab

--- a/docs/source/generated/alfred3.element.display.Image.rightlab.rst
+++ b/docs/source/generated/alfred3.element.display.Image.rightlab.rst
@@ -1,0 +1,6 @@
+Image.rightlab
+======================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Image.rightlab

--- a/docs/source/generated/alfred3.element.display.Image.rst
+++ b/docs/source/generated/alfred3.element.display.Image.rst
@@ -1,4 +1,4 @@
-Image
+﻿Image
 =============================
 
 .. currentmodule:: alfred3.element.display
@@ -49,6 +49,7 @@ Image
 
       
          ~Image.base_template
+         ~Image.bottomlab
          ~Image.converted_width
          ~Image.css_class_container
          ~Image.css_class_element
@@ -62,14 +63,19 @@ Image
          ~Image.font_size
          ~Image.js_code
          ~Image.js_urls
+         ~Image.labels
+         ~Image.layout
+         ~Image.leftlab
          ~Image.name
          ~Image.page
          ~Image.position
+         ~Image.rightlab
          ~Image.section
          ~Image.short_tree
          ~Image.should_be_shown
          ~Image.showif
          ~Image.template_data
+         ~Image.toplab
          ~Image.tree
          ~Image.web_widget
          ~Image.width

--- a/docs/source/generated/alfred3.element.display.Image.toplab.rst
+++ b/docs/source/generated/alfred3.element.display.Image.toplab.rst
@@ -1,0 +1,6 @@
+Image.toplab
+====================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Image.toplab

--- a/docs/source/generated/alfred3.element.display.Video.bottomlab.rst
+++ b/docs/source/generated/alfred3.element.display.Video.bottomlab.rst
@@ -1,0 +1,6 @@
+Video.bottomlab
+=======================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Video.bottomlab

--- a/docs/source/generated/alfred3.element.display.Video.labels.rst
+++ b/docs/source/generated/alfred3.element.display.Video.labels.rst
@@ -1,0 +1,6 @@
+Video.labels
+====================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Video.labels

--- a/docs/source/generated/alfred3.element.display.Video.layout.rst
+++ b/docs/source/generated/alfred3.element.display.Video.layout.rst
@@ -1,0 +1,6 @@
+Video.layout
+====================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Video.layout

--- a/docs/source/generated/alfred3.element.display.Video.leftlab.rst
+++ b/docs/source/generated/alfred3.element.display.Video.leftlab.rst
@@ -1,0 +1,6 @@
+Video.leftlab
+=====================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Video.leftlab

--- a/docs/source/generated/alfred3.element.display.Video.rightlab.rst
+++ b/docs/source/generated/alfred3.element.display.Video.rightlab.rst
@@ -1,0 +1,6 @@
+Video.rightlab
+======================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Video.rightlab

--- a/docs/source/generated/alfred3.element.display.Video.rst
+++ b/docs/source/generated/alfred3.element.display.Video.rst
@@ -1,4 +1,4 @@
-Video
+﻿Video
 =============================
 
 .. currentmodule:: alfred3.element.display
@@ -49,6 +49,7 @@ Video
 
       
          ~Video.base_template
+         ~Video.bottomlab
          ~Video.converted_width
          ~Video.css_class_container
          ~Video.css_class_element
@@ -62,14 +63,19 @@ Video
          ~Video.font_size
          ~Video.js_code
          ~Video.js_urls
+         ~Video.labels
+         ~Video.layout
+         ~Video.leftlab
          ~Video.name
          ~Video.page
          ~Video.position
+         ~Video.rightlab
          ~Video.section
          ~Video.short_tree
          ~Video.should_be_shown
          ~Video.showif
          ~Video.template_data
+         ~Video.toplab
          ~Video.tree
          ~Video.web_widget
          ~Video.width

--- a/docs/source/generated/alfred3.element.display.Video.toplab.rst
+++ b/docs/source/generated/alfred3.element.display.Video.toplab.rst
@@ -1,0 +1,6 @@
+Video.toplab
+====================================
+
+.. currentmodule:: alfred3.element.display
+
+.. autoproperty:: Video.toplab

--- a/docs/source/generated/alfred3.experiment.ExperimentSession.finish.rst
+++ b/docs/source/generated/alfred3.experiment.ExperimentSession.finish.rst
@@ -1,0 +1,6 @@
+ExperimentSession.finish()
+===========================================
+
+.. currentmodule:: alfred3.experiment
+
+.. automethod:: ExperimentSession.finish

--- a/docs/source/generated/alfred3.experiment.ExperimentSession.rst
+++ b/docs/source/generated/alfred3.experiment.ExperimentSession.rst
@@ -1,4 +1,4 @@
-ExperimentSession
+﻿ExperimentSession
 ====================================
 
 .. currentmodule:: alfred3.experiment
@@ -34,6 +34,9 @@ ExperimentSession
    
    
       ~ExperimentSession.encrypt
+   
+   
+      ~ExperimentSession.finish
    
    
       ~ExperimentSession.forward

--- a/src/alfred3/_version.py
+++ b/src/alfred3/_version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"

--- a/src/alfred3/experiment.py
+++ b/src/alfred3/experiment.py
@@ -657,6 +657,7 @@ class ExperimentSession:
                 f"Experiment version: {self.version}"
             )
         )
+        self._save_data(sync=True)
 
     def append_plugin_data_query(self, query: dict):
         """


### PR DESCRIPTION
## alfred3 v2.1.1 (Released 2021-05-18)

### Changed v2.1.1

- We now save a basic skeleton of an experiment's data directly on 
  initializing a session. While this introduces a short delay (max 1s)
  upon starting an experiment, this makes it easier for plugins such
  as `alfred3_interact` to rely on certain data being available during 
  setup.