### PR TITLE
alfred3 v2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/).
 <!-- and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). -->
 
+## alfred3 v2.1.3 (Released 2021-06-01)
+
+### Fixed v2.1.3
+
+- Fixed a bug in `ListRandomizer` that impaired the allocation of excat numbers
+  of participants to conditions. With this bug, random allocation to conditions
+  was not affected, but the `ListRandomizer` operated like a true pseudo-random
+  allocator instead of using actual list randomization: If you defined conditions
+  "a" and "b" to get 20 participants each, you may have ended up with 22 
+  participants in condition "a" and 26 in condition "b" instead.
+  This was update fixes this bug and includes 19 automatic unit tests that make
+  sure that the randomizer works as intended.
+
+### Removed v2.1.3
+
+- Removed the parameter `timeout` from `ListRandomizer`. The randomizer will now
+  always use the `ExperimentSession.session_timeout` to determine whether a
+  session is expired.
+
 ## alfred3 v2.1.2 (Released 2021-05-27)
 
 ### Added v2.1.2

--- a/src/alfred3/_version.py
+++ b/src/alfred3/_version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 
-__version__ = "2.1.2"
+__version__ = "2.1.3"

--- a/src/alfred3/condition.py
+++ b/src/alfred3/condition.py
@@ -593,7 +593,7 @@ class ListRandomizer:
         elif data and data["assignment_ongoing"]:
             data = self.io.load() # load data again, this time respecting assignment_ongoing
         
-        self._check_consistency(data)
+        self._validate(data)
         self.slotlist = _SlotList(*data["slots"])
 
         if self.full:

--- a/src/alfred3/condition.py
+++ b/src/alfred3/condition.py
@@ -3,6 +3,7 @@ Provides functionality for assigning participants to experiment conditions.
 """
 
 from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from typing import Tuple, List, Iterator
 from pathlib import Path
 from uuid import uuid4
@@ -23,6 +24,7 @@ class ConditionInconsistency(AssertionError):
 class _Session:
     id: str
     timestamp: float = time.time()
+    timestamp: float = field(default_factory=time.time)
 
 
 @dataclass

--- a/src/alfred3/condition.py
+++ b/src/alfred3/condition.py
@@ -212,15 +212,6 @@ class ListRandomizer:
 
             Defaults to 'strict'.
         
-        timeout (int): Timeout in seconds. After timeout expiration,
-            sessions are regarded as expired. Their condition slots will
-            be marked as open again. If None (default), the Randomizer 
-            will use the :attr:`.ExperimentSession.session_timeout`, which
-            is highly recommended. Using a shorter timeout than the 
-            session timeout might result in a situation where a session
-            that the Randomizer regarded as expired ends up still finishing
-            the experiment.
-        
         random_seed: The random seed used for reproducible pseudo-random
             behavior. This seed will be used for shuffling the condition
             list. Defaults to the current system time. Valid seeds are
@@ -341,7 +332,6 @@ class ListRandomizer:
         id: str = None,
         respect_version: bool = True,
         mode: str = "strict",
-        timeout: int = None,
         random_seed=None,
         abort_page=None,
     ):
@@ -350,7 +340,7 @@ class ListRandomizer:
         self.exp.finish_functions.append(self._mark_slot_finished)
         self.respect_version = respect_version
         self.mode = mode
-        self.timeout = timeout if timeout is not None else self.exp.session_timeout
+        self.timeout = self.exp.session_timeout
         self.random_seed = random_seed if random_seed is not None else time.time()
         self.conditions = conditions
         self.abort_page = abort_page

--- a/src/alfred3/experiment.py
+++ b/src/alfred3/experiment.py
@@ -658,6 +658,7 @@ class ExperimentSession:
             )
         )
         self._save_data(sync=True)
+        
 
     def append_plugin_data_query(self, query: dict):
         """
@@ -2015,7 +2016,10 @@ class ExperimentSession:
         """
         str: A human-readable string, indicating the start time.
         """
-        return time.strftime("%Y-%m-%d_%H:%M:%S", time.localtime(self._start_time))
+        if self._start_time:
+            return time.strftime("%Y-%m-%d_%H:%M:%S", time.localtime(self._start_time))
+        else:
+            return None
 
     @property
     def start_time(self):

--- a/src/alfred3/ui_controller.py
+++ b/src/alfred3/ui_controller.py
@@ -310,7 +310,9 @@ class MovementManager:
         """
         to_page = self.find_page(query=to)
         self.log.debug(f"Direct jump to {to_page}. Skipping all normal move function.")
-        if self.exp.config.getboolean("data", "record_move_history"):
+        if not self.exp.start_time:
+            pass
+        elif self.exp.config.getboolean("data", "record_move_history"):
                 self.record_move(self.current_page.is_closed, direction="jump", to_page=to_page)
          
         self.current_index = self.index_of(to_page)

--- a/tests/test_condition.py
+++ b/tests/test_condition.py
@@ -1,0 +1,346 @@
+import random
+import pytest
+
+import alfred3 as al
+from alfred3.condition import ConditionInconsistency
+
+from .util import get_exp_session, clear_db
+
+@pytest.fixture
+def exp(tmp_path):
+    script = "tests/res/script-hello_world.py"
+    secrets = "tests/res/secrets-default.conf"
+    exp = get_exp_session(tmp_path, script_path=script, secrets_path=secrets)
+    
+    yield exp
+
+    clear_db()
+
+
+@pytest.fixture
+def exp_factory(tmp_path):
+    def expf():
+        script = "tests/res/script-hello_world.py"
+        secrets = "tests/res/secrets-default.conf"
+        exp = get_exp_session(tmp_path, script_path=script, secrets_path=secrets)
+        return exp
+    
+    yield expf
+
+    clear_db()
+
+
+@pytest.fixture
+def lexp(tmp_path):
+    script = "tests/res/script-hello_world.py"
+    exp = get_exp_session(tmp_path, script_path=script, secrets_path=None)
+    yield exp
+
+
+
+@pytest.fixture
+def strict_exp(exp):
+    rd = al.ListRandomizer(("a", 10), ("b", 10), exp=exp)
+    exp.condition = rd.get_condition()
+    yield exp
+
+
+def test_clear(exp):
+    """
+    Just for clearing the database in case a test breaks down with an error.
+    """
+    print(exp)
+
+class TestConditionValidation:
+
+    def test_pass_validation(self, strict_exp):
+        rd = al.ListRandomizer(("a", 10), ("b", 10), exp=strict_exp)
+        assert rd.get_condition()
+    
+    def test_change_mode(self, strict_exp):
+        rd = al.ListRandomizer(("a", 10), ("b", 10), exp=strict_exp, mode="inclusive")
+        assert rd.get_condition()
+    
+    def test_change_of_n(self, strict_exp):
+
+        rd = al.ListRandomizer(("a", 10), ("b", 9), exp=strict_exp)
+        with pytest.raises(ConditionInconsistency):
+            rd.get_condition()
+        
+    def test_change_of_name(self, strict_exp):
+
+        rd = al.ListRandomizer(("a", 10), ("c", 10), exp=strict_exp)
+        with pytest.raises(ConditionInconsistency):
+            rd.get_condition()
+
+    def test_add_condition(self, strict_exp):
+
+        rd = al.ListRandomizer(("a", 10), ("b", 10), ("c", 10), exp=strict_exp)
+        with pytest.raises(ConditionInconsistency):
+            rd.get_condition()
+
+    def test_remove_condition(self, strict_exp):
+        rd = al.ListRandomizer(("a", 10), exp=strict_exp)
+        with pytest.raises(ConditionInconsistency):
+            rd.get_condition()
+
+    def test_increase_version(self, strict_exp):
+        strict_exp.config.read_dict({"metadata": {"version": "0.2"}})
+        assert strict_exp.version == "0.2"
+        
+        rd = al.ListRandomizer(("a", 10), exp=strict_exp)
+        assert rd.get_condition()
+    
+
+def rd_slots(*conditions, exp, seed):
+    rd = al.ListRandomizer(*conditions, exp=exp, random_seed=seed)
+    rd.get_condition()
+
+    rd_slots = [slot.condition for slot in rd.slotlist.slots]
+    return rd_slots
+
+
+def slots(*conditions, seed):
+    slots = []
+    for c, n in conditions:
+        slots += [c] * n
+    random.seed(seed)
+    random.shuffle(slots)
+    return slots
+
+
+class TestConditionShuffle:
+
+    def test_shuffle_mongo(self, exp):
+        conditions = [("a", 20), ("b", 20)]
+        seed1 = 123
+        s1 = rd_slots(*conditions, exp=exp, seed=seed1)
+
+        exp.config.read_dict({"metadata": {"version": "0.2"}})
+        seed2 = 12345
+        s2 = rd_slots(*conditions, exp=exp, seed=seed2)
+
+        assert s1 != s2
+
+
+    def test_shuffle_seed_mongo(self, exp):
+        conditions = [("a", 20), ("b", 20)]
+        seed = 12345
+        
+        s1 = rd_slots(*conditions, exp=exp, seed=seed)
+        s2 = slots(*conditions, seed=seed)
+
+        assert s1 == s2
+    
+
+    def test_shuffle_local(self, lexp):
+        conditions = [("a", 20), ("b", 20)]
+        seed1 = 123
+        s1 = rd_slots(*conditions, exp=lexp, seed=seed1)
+
+        lexp.config.read_dict({"metadata": {"version": "0.2"}})
+        seed2 = 12345
+        s2 = rd_slots(*conditions, exp=lexp, seed=seed2)
+
+        assert s1 != s2
+
+
+    def test_shuffle_seed_local(self, lexp):
+        conditions = [("a", 20), ("b", 20)]
+        seed = 12345
+
+        s1 = rd_slots(*conditions, exp=lexp, seed=seed)
+        s2 = slots(*conditions, seed=seed)
+
+        assert s1 == s2
+
+
+class TestConditionAllocation:
+    
+    def test_aborted_session(self, exp_factory):
+        exp1 = exp_factory()
+        seed = 12348
+        exp1._session_id = "exp1"
+        rd1 = al.ListRandomizer.balanced("a", "b", n=10, exp=exp1, random_seed=seed)
+        exp1.condition = rd1.get_condition()
+
+        slots = rd1.slotlist.slots
+        assert exp1.condition == slots[0].condition
+        assert slots[0].condition != slots[1].condition
+
+        exp1._start()
+        exp1.abort("test")
+        exp1._save_data(sync=True)
+
+        exp1_session = rd1.slotlist.slots[0].sessions[0]
+        assert not exp1_session.active(exp1)
+
+        exp2 = exp_factory()
+        exp2._session_id = "exp2"
+        rd2 = al.ListRandomizer.balanced("a", "b", n=10, exp=exp2, random_seed=seed)
+        exp2.condition = rd2.get_condition()
+        assert exp2.condition == exp1.condition
+    
+
+    def test_active_session(self, exp_factory):
+        exp1 = exp_factory()
+        seed = 12348
+        exp1._session_id = "exp1"
+        rd1 = al.ListRandomizer.balanced("a", "b", n=10, exp=exp1, random_seed=seed)
+        exp1.condition = rd1.get_condition()
+
+        exp1._start()
+        exp1._save_data(sync=True)
+
+        exp1_session = rd1.slotlist.slots[0].sessions[0]
+        assert exp1_session.active(exp1)
+
+        exp2 = exp_factory()
+        exp2._session_id = "exp2"
+        rd2 = al.ListRandomizer.balanced("a", "b", n=10, exp=exp2, random_seed=seed)
+        exp2.condition = rd2.get_condition()
+
+        assert exp2.condition != exp1.condition
+    
+
+    def test_finished_session(self, exp_factory):
+        exp1 = exp_factory()
+        seed = 12348
+        exp1._session_id = "exp1"
+        rd1 = al.ListRandomizer.balanced("a", "b", n=10, exp=exp1, random_seed=seed)
+        exp1.condition = rd1.get_condition()
+
+        exp1._start()
+        exp1.finish()
+
+        slot1 = rd1.slotlist.slots[0]
+        exp1_session = slot1.sessions[0]
+        
+        assert slot1.finished
+        assert not exp1_session.active(exp1)
+
+        exp2 = exp_factory()
+        exp2._session_id = "exp2"
+        rd2 = al.ListRandomizer.balanced("a", "b", n=10, exp=exp2, random_seed=seed)
+        exp2.condition = rd2.get_condition()
+
+        assert exp2.condition != exp1.condition
+    
+
+    def test_expired_session(self, exp_factory):
+        exp1 = exp_factory()
+        seed = 12348
+        exp1._session_id = "exp1"
+        rd1 = al.ListRandomizer.balanced("a", "b", n=10, exp=exp1, random_seed=seed)
+        exp1.condition = rd1.get_condition()
+
+        exp1._start()
+        exp1._start_time = exp1._start_time - exp1.session_timeout - 1
+
+        assert exp1.session_expired
+        exp1._save_data(sync=True)
+
+        slot1 = rd1.slotlist.slots[0]
+        exp1_session = slot1.sessions[0]
+        
+        assert not slot1.finished
+        assert not exp1_session.active(exp1)
+
+        exp2 = exp_factory()
+        exp2._session_id = "exp2"
+        rd2 = al.ListRandomizer.balanced("a", "b", n=10, exp=exp2, random_seed=seed)
+        exp2.condition = rd2.get_condition()
+
+        assert exp2.condition == exp1.condition
+    
+
+    def test_slots_full_strict(self, exp_factory):
+        exp1 = exp_factory()
+        seed = 12348
+        exp1._session_id = "exp1"
+        rd1 = al.ListRandomizer.balanced("a", "b", n=1, exp=exp1, random_seed=seed)
+        exp1.condition = rd1.get_condition()
+        exp1._start()
+        exp1._save_data(sync=True)
+
+        exp2 = exp_factory()
+        exp2._session_id = "exp2"
+        rd2 = al.ListRandomizer.balanced("a", "b", n=1, exp=exp2, random_seed=seed)
+        exp2.condition = rd2.get_condition()
+        exp2._start()
+        exp2._save_data(sync=True)
+
+        exp3 = exp_factory()
+        exp3._session_id = "exp3"
+        rd3 = al.ListRandomizer.balanced("a", "b", n=1, exp=exp3, random_seed=seed)
+        exp3.condition = rd3.get_condition()
+
+        assert exp3.aborted
+    
+    def test_slots_inclusive(self, exp_factory):
+        exp1 = exp_factory()
+        seed = 12348
+        exp1._session_id = "exp1"
+        rd1 = al.ListRandomizer.balanced("a", "b", n=1, exp=exp1, random_seed=seed, mode = "inclusive")
+        exp1.condition = rd1.get_condition()
+        exp1._start()
+        exp1.finish()
+
+        exp2 = exp_factory()
+        exp2._session_id = "exp2"
+        rd2 = al.ListRandomizer.balanced("a", "b", n=1, exp=exp2, random_seed=seed, mode = "inclusive")
+        exp2.condition = rd2.get_condition()
+        exp2._start()
+
+        assert exp1.condition != exp2.condition
+
+        exp3 = exp_factory()
+        exp3._session_id = "exp3"
+        rd3 = al.ListRandomizer.balanced("a", "b", n=1, exp=exp3, random_seed=seed, mode = "inclusive")
+        exp3.condition = rd3.get_condition()
+
+        assert exp2.condition == exp3.condition
+
+    
+    def test_slots_full_inclusive(self, exp_factory):
+        exp1 = exp_factory()
+        seed = 12348
+        exp1._session_id = "exp1"
+        rd1 = al.ListRandomizer.balanced("a", "b", n=1, exp=exp1, random_seed=seed, mode = "inclusive")
+        exp1.condition = rd1.get_condition()
+        exp1._start()
+        exp1.finish()
+
+        exp2 = exp_factory()
+        exp2._session_id = "exp2"
+        rd2 = al.ListRandomizer.balanced("a", "b", n=1, exp=exp2, random_seed=seed, mode = "inclusive")
+        exp2.condition = rd2.get_condition()
+        exp2._start()
+        exp2.finish()
+
+        assert exp1.condition != exp2.condition
+
+        exp3 = exp_factory()
+        exp3._session_id = "exp3"
+        rd3 = al.ListRandomizer.balanced("a", "b", n=1, exp=exp3, random_seed=seed, mode = "inclusive")
+        exp3.condition = rd3.get_condition()
+
+        assert exp3.aborted
+
+    def test_balanced_constructor(self, exp_factory):
+        exp1 = exp_factory()
+        seed = 12348
+        exp1._session_id = "exp1"
+        rd1 = al.ListRandomizer.balanced("a", "b", n=10, exp=exp1, random_seed=seed)
+        exp1.condition = rd1.get_condition()
+
+
+        exp2 = exp_factory()
+        exp2._session_id = "exp2"
+        rd2 = al.ListRandomizer(("a", 10), ("b", 10), exp=exp2, random_seed=seed)
+        exp2.condition = rd2.get_condition()
+
+        slots1 = [s.condition for s in rd1.slotlist.slots]
+        slots2 = [s.condition for s in rd2.slotlist.slots]
+        assert slots1 == slots2
+

--- a/tests/util.py
+++ b/tests/util.py
@@ -34,7 +34,7 @@ def prepare_config(tmp_path, config_path: str) -> str:
     Does nothing if config_path is an empty string.
     """
     if not config_path:
-        return
+        return ExperimentConfig(expdir=tmp_path)
     config = Path(config_path).read_text()
     tmp_config = Path(tmp_path) / "config.conf"
     tmp_config.write_text(config)
@@ -135,9 +135,6 @@ def get_exp_session(
 
     session = exp.create_session(session_id=sid, config=config, secrets=secrets, **urlargs)
     return session
-
-
-
 
 
 def get_app(


### PR DESCRIPTION
## alfred3 v2.1.3 (Released 2021-06-01)

### Fixed v2.1.3

- Fixed a bug in `ListRandomizer` that impaired the allocation of excat numbers
  of participants to conditions. With this bug, random allocation to conditions
  was not affected, but the `ListRandomizer` operated like a true pseudo-random
  allocator instead of using actual list randomization: If you defined conditions
  "a" and "b" to get 20 participants each, you may have ended up with 22 
  participants in condition "a" and 26 in condition "b" instead.
  This was update fixes this bug and includes 19 automatic unit tests that make
  sure that the randomizer works as intended.

### Removed v2.1.3

- Removed the parameter `timeout` from `ListRandomizer`. The randomizer will now
  always use the `ExperimentSession.session_timeout` to determine whether a
  session is expired.