### PR TITLE
Refactor session timeout handling and update documentation

### DIFF
--- a/src/alfred3/experiment.py
+++ b/src/alfred3/experiment.py
@@ -88,8 +88,7 @@ class Experiment:
 
     """
 
-    def __init__(self, session_timeout: int = 60 * 60 * 24):
-        self.session_timeout = session_timeout
+    def __init__(self):
         self._final_page = None
 
         #: A dictionary of all pages and sections added to the experiment.
@@ -403,7 +402,6 @@ class Experiment:
         session_id: str,
         config: ExperimentConfig,
         secrets: ExperimentSecrets,
-        timeout: int = None,
         **urlargs,
     ):
         """
@@ -433,12 +431,10 @@ class Experiment:
         if urlargs.get("debug") in ["true", "True", "TRUE"]:
             config.read_dict({"general": {"debug": True}})
 
-        timeout = timeout if timeout is not None else self.session_timeout
         exp_session = ExperimentSession(
             session_id=session_id,
             config=config,
             secrets=secrets,
-            timeout=timeout,
             **urlargs,
         )
 
@@ -683,7 +679,6 @@ class ExperimentSession:
         session_id: str,
         config: ExperimentConfig = None,
         secrets: ExperimentSecrets = None,
-        timeout: int = None,
         **urlargs,
     ):
 
@@ -702,7 +697,9 @@ class ExperimentSession:
         self._condition = ""  # docs in getter
         self._session = ""  # docs in getter
 
-        self.session_timeout = timeout  # docs in getter
+        self._session_timeout = config.getint(
+            "general", "session_timeout"
+        )  # docs in getter
         self.finished: bool = False  # docs in getter
         self.aborted: bool = False  # docs in getter
 
@@ -2242,17 +2239,7 @@ class ExperimentSession:
         the next move.
 
         The default timeout is 24 hours. You can set the timeout in
-        experiment setup. In the example below, we set the timeout
-        to two hours::
-
-            import alfred3 as al
-            exp = al.Experiment()
-
-            @exp.setup
-            def setup(exp):
-                exp.session_timeout = 60 * 60 * 2
-
-            exp += al.Page(name="demo")
+        the config.conf.
 
         See Also:
             :attr:`.session_expired`
@@ -2262,6 +2249,10 @@ class ExperimentSession:
 
     @session_timeout.setter
     def session_timeout(self, value):
+        self.log.warning(
+            "Setting the session timeout directly is deprecated. Please set it in"
+            " config.conf."
+        )
         if value is not None and not isinstance(value, (int, float)):
             raise TypeError
         self._session_timeout = value

--- a/src/alfred3/files/alfred.conf
+++ b/src/alfred3/files/alfred.conf
@@ -25,7 +25,7 @@ fullscreen = false              # If true (and Chrome is available), the exp sta
 debug = false                   # If true, the exp starts in debug mode
 admin = false                   # If true, the exp starts in admin mode
 force_input = false             # If true, input elements are force input by default
-
+session_timeout = 86400         # Session timeout in seconds. The default is 24 * 60 * 60 = 86400 seconds, which is 24 hours. This counts from the START of the experiment, not from the last activity.
 
 # SECTION: data --------------------------------------------------------
 # General configuration for data collection and export.

--- a/src/alfred3/testutil.py
+++ b/src/alfred3/testutil.py
@@ -131,7 +131,6 @@ def get_exp_session(
     config_path: str = "",
     secrets_path: str = "tests/res/secrets-default.conf",
     sid: str = None,
-    timeout: int = None,
     **urlargs,
 ):
     """
@@ -147,7 +146,7 @@ def get_exp_session(
     sid = uuid4().hex if sid is None else sid
 
     session = exp.create_session(
-        session_id=sid, config=config, secrets=secrets, timeout=timeout, **urlargs
+        session_id=sid, config=config, secrets=secrets, **urlargs
     )
     return session
 


### PR DESCRIPTION
Closes #212.

However, I feel cautious about this one. The session timeout was embedded deeper into the code than I thought, it was an init argument to both `Experiment`  and `ExperimentSession`. Therefore, this PR definitely requires verification with mortimer before deployment.